### PR TITLE
Run SVD without converting through a dense matrix

### DIFF
--- a/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
+++ b/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
@@ -11,7 +11,6 @@ import Foreign hiding (unsafePerformIO)
 import Foreign.C.Types
 import System.IO.Unsafe
 import Foreign.Marshal.Alloc
-import Debug.Trace
 import System.IO
 
 newtype DenseMatrix = DMat (ForeignPtr DenseMatrix)
@@ -149,7 +148,7 @@ shiftCSR csr = csr {
 -- but does not require making the whole matrix dense first
 sparseSvd :: Int -> I.CSR -> (P.Matrix Double, P.Vector Double, P.Matrix Double)
 sparseSvd rank m = unsafePerformIO $
-    setVerbosity 1
+    setVerbosity 0
     >>  (wrapSMatrix $ shiftCSR m)
     >>= runSvd rank
     >>= unpackSvdRec

--- a/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
+++ b/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
@@ -22,7 +22,7 @@ newtype SparseMatrix = SMat (ForeignPtr SparseMatrix)
                      deriving (Eq, Ord, Show)
 
 foreign import ccall unsafe "svdNewSMat" _newSMat :: CInt -> CInt -> IO (Ptr SparseMatrix)
-foreign import ccall unsafe "svd_new_smat_from_csrT" _newSMatFromCSRT :: CInt -> CInt -> CInt -> Ptr CLong -> Ptr CLong -> Ptr Double -> IO (Ptr SparseMatrix)
+foreign import ccall unsafe "svd_new_smat_from_csr" _newSMatFromCSRT :: CInt -> CInt -> CInt -> Ptr CLong -> Ptr CLong -> Ptr Double -> IO (Ptr SparseMatrix)
 foreign import ccall unsafe "&svdFreeSMat" p_freeSMat :: FunPtr (Ptr SparseMatrix -> IO ())
 foreign import ccall unsafe "svdTransposeS" _transposeSMat :: Ptr SparseMatrix -> IO (Ptr SparseMatrix)
 

--- a/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
+++ b/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
@@ -4,8 +4,8 @@ module Numeric.LinearAlgebra.SVD.SVDLIBC
     (svd) where
 
 import Control.Applicative
-import qualified Data.Packed as P
-import qualified Data.Packed.Development as I
+import qualified Numeric.LinearAlgebra.Data as P
+import qualified Numeric.LinearAlgebra.Devel as I
 import Foreign hiding (unsafePerformIO)
 import Foreign.C.Types
 import System.IO.Unsafe
@@ -98,4 +98,11 @@ unpackSvdRec (SVDRec fptr) = withForeignPtr fptr $ \ptr->do
 -- This function handles the conversion to svdlibc's sparse representation.
 svd :: Int -> P.Matrix Double -> (P.Matrix Double, P.Vector Double, P.Matrix Double)
 svd rank m = unsafePerformIO $ do
+    setVerbosity 0 >> matrixToDMatrix m >>= dMatrixToSMatrix >>= runSvd rank >>= unpackSvdRec
+
+-- | @svd rank a@ is the sparse SVD of matrix @a@ with the given rank
+-- This function handles the conversion to svdlibc's sparse representation,
+-- but does not require making the whole matrix dense first
+sparseSvd :: Int -> P.Matrix Double -> (P.Matrix Double, P.Vector Double, P.Matrix Double)
+sparseSvd rank m = unsafePerformIO $ do
     setVerbosity 0 >> matrixToDMatrix m >>= dMatrixToSMatrix >>= runSvd rank >>= unpackSvdRec

--- a/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
+++ b/Numeric/LinearAlgebra/SVD/SVDLIBC.hs
@@ -6,10 +6,13 @@ module Numeric.LinearAlgebra.SVD.SVDLIBC
 import Control.Applicative
 import qualified Numeric.LinearAlgebra.Data as P
 import qualified Numeric.LinearAlgebra.Devel as I
+import qualified Data.Vector.Storable as Vec
 import Foreign hiding (unsafePerformIO)
 import Foreign.C.Types
 import System.IO.Unsafe
 import Foreign.Marshal.Alloc
+import Debug.Trace
+import System.IO
 
 newtype DenseMatrix = DMat (ForeignPtr DenseMatrix)
                     deriving (Eq, Ord, Show)
@@ -20,8 +23,7 @@ newtype SparseMatrix = SMat (ForeignPtr SparseMatrix)
                      deriving (Eq, Ord, Show)
 
 foreign import ccall unsafe "svdNewSMat" _newSMat :: CInt -> CInt -> IO (Ptr SparseMatrix)
---svd_new_smat_from_csr(int rows, int cols, int vals, long *pointr, long *rowind, double *value)
-foreign import ccall unsafe "svd_new_smat_from_csr" _newSMatFromCSR :: CInt -> CInt -> CInt -> Ptr CInt -> Ptr CInt -> Ptr Double -> IO (Ptr SparseMatrix)
+foreign import ccall unsafe "svd_new_smat_from_csrT" _newSMatFromCSRT :: CInt -> CInt -> CInt -> Ptr CLong -> Ptr CLong -> Ptr Double -> IO (Ptr SparseMatrix)
 foreign import ccall unsafe "&svdFreeSMat" p_freeSMat :: FunPtr (Ptr SparseMatrix -> IO ())
 foreign import ccall unsafe "svdTransposeS" _transposeSMat :: Ptr SparseMatrix -> IO (Ptr SparseMatrix)
 
@@ -60,21 +62,17 @@ asSMat ptr = SMat <$> newForeignPtr p_freeSMat ptr
 wrapSMatrix :: I.CSR -> IO SparseMatrix
 wrapSMatrix csr = do
   let tfst (x,_,_) = x
-  withForeignPtr (tfst $ I.unsafeToForeignPtr $ I.csrRows csr) $ \rowvec ->
-    withForeignPtr (tfst $ I.unsafeToForeignPtr $ I.csrCols csr) $ \colvec ->
-      withForeignPtr (tfst $ I.unsafeToForeignPtr $ I.csrVals csr) $ \valvec ->
-        _newSMatFromCSR
+  Vec.unsafeWith (Vec.map fromIntegral $ I.csrRows csr) $ \rowvec ->
+    Vec.unsafeWith (Vec.map fromIntegral $ I.csrCols csr) $ \colvec ->
+      Vec.unsafeWith (I.csrVals csr) $ \valvec -> do
+        smatptr <- _newSMatFromCSRT
           (fromIntegral $ I.csrNRows csr)
           (fromIntegral $ I.csrNCols csr)
           (fromIntegral $ P.size $ I.csrVals csr)
           rowvec
           colvec
           valvec
-          >>= asSMat
-
-createSMatrix :: Int -> Int -> IO SparseMatrix
-createSMatrix rows cols = do
-    _newSMat (fromIntegral rows) (fromIntegral cols) >>= asSMat
+        asSMat smatptr
 
 transposeSMatrix :: SparseMatrix -> IO SparseMatrix
 transposeSMatrix (SMat fptr) = withForeignPtr fptr $ \ptr->
@@ -121,24 +119,37 @@ unpackSvdRec (SVDRec fptr) = withForeignPtr fptr $ \ptr->do
 -- This function handles the conversion to svdlibc's sparse representation.
 svd :: Int -> P.Matrix Double -> (P.Matrix Double, P.Vector Double, P.Matrix Double)
 svd rank m = unsafePerformIO $ do
-    setVerbosity 0 >> matrixToDMatrix m >>= dMatrixToSMatrix >>= runSvd rank >>= unpackSvdRec
+    setVerbosity 0
+    >> matrixToDMatrix m
+    >>= dMatrixToSMatrix
+    >>= runSvd rank
+    >>= unpackSvdRec
 
 sparsify :: P.Matrix Double -> I.CSR
 sparsify mat = I.CSR {
     I.csrVals = P.flatten mat,
-    I.csrCols = P.fromList $ mconcat $ replicate rows [1..fromIntegral cols],
-    I.csrRows = P.fromList $ CInt <$> [1, i32cols+1 .. i32rows*i32cols+1],
+    -- The following are indexed from 1! This will be undone in sparseSvd(shiftCSR)
+    -- but it needs to match HMatrix's standard until then
+    I.csrCols = Vec.iterateN (rows*cols) (\x -> (x `mod` i32cols) + 1) 1,
+    I.csrRows = Vec.iterateN (rows+1) (+i32cols) 1,
     I.csrNRows = rows,
     I.csrNCols = cols
   } where
     (rows, cols) = P.size mat
     (i32rows, i32cols) = (fromIntegral rows, fromIntegral cols)
 
+shiftCSR :: I.CSR -> I.CSR
+shiftCSR csr = csr {
+    I.csrRows = Vec.map (subtract 1) $ I.csrRows csr,
+    I.csrCols = Vec.map (subtract 1) $ I.csrCols csr
+  }
+
 -- | @svd rank a@ is the sparse SVD of matrix @a@ with the given rank
 -- This function handles the conversion to svdlibc's sparse representation,
 -- but does not require making the whole matrix dense first
 sparseSvd :: Int -> I.CSR -> (P.Matrix Double, P.Vector Double, P.Matrix Double)
-sparseSvd rank m = unsafePerformIO $ do
-    setVerbosity 0
-    print m
-    wrapSMatrix m >>= runSvd rank >>= unpackSvdRec
+sparseSvd rank m = unsafePerformIO $
+    setVerbosity 1
+    >>  (wrapSMatrix $ shiftCSR m)
+    >>= runSvd rank
+    >>= unpackSvdRec

--- a/Test.hs
+++ b/Test.hs
@@ -1,9 +1,0 @@
-import Data.Packed as P
-import Numeric.LinearAlgebra.SVD.SVDLIBC as SVD
-import Numeric.LinearAlgebra
-
-main = do
-    let m = ident 100
-        (u,s,v) = SVD.svd 50 m
-    print $ s
-    print $ u `mXm` diag s `mXm` trans v

--- a/cbits/glue.c
+++ b/cbits/glue.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <svdlib.h>
 #include <glue.h>
 
@@ -33,6 +34,18 @@ struct smat {
   long *rowind;  // For each nz entry, the row index.
   double *value; // For each nz entry, the value.
 }; */
+
+SMat svd_new_smat_from_csr(int rows, int cols, int vals, long *pointr, long *rowind, double *value) {
+  SMat S = (SMat) calloc(1, sizeof(struct smat));
+  if (!S) {perror("svdNewSMat"); return NULL;}
+  S->rows = rows;
+  S->cols = cols;
+  S->vals = vals;
+  S->pointr = pointr;
+  S->rowind = rowind;
+  S->value  = value;
+  return S;
+}
 
 long get_smat_rows(SMat m) { return m->rows; };
 long get_smat_cols(SMat m) { return m->cols; };

--- a/cbits/glue.c
+++ b/cbits/glue.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <stdio.h>
 #include <svdlib.h>
 #include <glue.h>
 
@@ -37,29 +36,15 @@ struct smat {
 
 /** Take a matrix in CSR format (which is what HMatrix gives) and turn it into
     CSC format, meanwhile making a copy so that GC is happy.*/
-SMat svd_new_smat_from_csrT(int rows, int cols, int vals, long *rowstart, long *colind, double *csr_value) {
-  /*fprintf(stderr, "rows %d cols %d vals %d\nvals ", rows, cols, vals);
-  for (int val=0; val < vals; val++) fprintf(stderr, " %0.3f", csr_value[val]);
-  fprintf(stderr, "\n");
-  for (int row=0; row < rows; row++) {
-    for (int i=rowstart[row]; i < rowstart[row+1]; i++) {
-      fprintf(stderr, "m[r=%d c=%ld, i=%d]: %.03f", row, colind[i], i, csr_value[i]);
-    }
-    fprintf(stderr, "\n");
-  }*/
-
-  struct smat S1;
-  // A CSR matrix is the same as a Transposed CSC
-  S1.rows = cols;
-  S1.cols = rows;
-  S1.vals = vals;
-  S1.pointr = rowstart;
-  S1.rowind = colind;
-  S1.value  = csr_value;
-  fprintf(stderr, "Transposing\n");
-  SMat S2 = svdTransposeS(&S1);
-  fprintf(stderr, "transposed\n");
-  return S2;
+SMat svd_new_smat_from_csr(int rows, int cols, int vals, long *rowstart, long *colind, double *csr_value) {
+  return svdTransposeS(& (struct smat){
+    .rows = cols,
+    .cols = rows,
+    .vals = vals,
+    .pointr = rowstart,
+    .rowind = colind,
+    .value  = csr_value
+  });
 }
 
 long get_smat_rows(SMat m) { return m->rows; };

--- a/cbits/glue.c
+++ b/cbits/glue.c
@@ -2,6 +2,14 @@
 #include <svdlib.h>
 #include <glue.h>
 
+/* For reference, this is from svdlib.h
+Row-major dense matrix.  Rows are consecutive vectors.
+struct dmat {
+  long rows;
+  long cols;
+  double **value; // Accessed by [row][col]. Free value[0] and value to free.
+}; */
+
 DMat get_svdrec_ut(SVDRec s) { return s->Ut; }
 double *get_svdrec_s(SVDRec s) { return s->S; }
 DMat get_svdrec_vt(SVDRec s) { return s->Vt; }
@@ -15,5 +23,28 @@ void free_dmat(DMat d) {
   free(d->value);
   free(d);
 }
+
+/* For reference, this is in svdlib.h: Harwell-Boeing sparse matrix.
+struct smat {
+  long rows;
+  long cols;
+  long vals;     // Total non-zero entries.
+  long *pointr;  // For each col (plus 1), index of first non-zero entry.
+  long *rowind;  // For each nz entry, the row index.
+  double *value; // For each nz entry, the value.
+}; */
+
+long get_smat_rows(SMat m) { return m->rows; };
+long get_smat_cols(SMat m) { return m->cols; };
+long *get_smat_pointr(SMat m) { return m->pointr; };
+long *get_smat_rowind(SMat m) { return m->rowind; };
+double *get_smat_value(SMat m) { return m->value; };
+
+void free_smat(SMat m) {
+  free(m->pointr);
+  free(m->rowind);
+  free(m->value);
+  free(m);
+};
 
 void set_verbosity(long v) { SVDVerbosity = v; }

--- a/cbits/glue.c
+++ b/cbits/glue.c
@@ -35,16 +35,31 @@ struct smat {
   double *value; // For each nz entry, the value.
 }; */
 
-SMat svd_new_smat_from_csr(int rows, int cols, int vals, long *pointr, long *rowind, double *value) {
-  SMat S = (SMat) calloc(1, sizeof(struct smat));
-  if (!S) {perror("svdNewSMat"); return NULL;}
-  S->rows = rows;
-  S->cols = cols;
-  S->vals = vals;
-  S->pointr = pointr;
-  S->rowind = rowind;
-  S->value  = value;
-  return S;
+/** Take a matrix in CSR format (which is what HMatrix gives) and turn it into
+    CSC format, meanwhile making a copy so that GC is happy.*/
+SMat svd_new_smat_from_csrT(int rows, int cols, int vals, long *rowstart, long *colind, double *csr_value) {
+  /*fprintf(stderr, "rows %d cols %d vals %d\nvals ", rows, cols, vals);
+  for (int val=0; val < vals; val++) fprintf(stderr, " %0.3f", csr_value[val]);
+  fprintf(stderr, "\n");
+  for (int row=0; row < rows; row++) {
+    for (int i=rowstart[row]; i < rowstart[row+1]; i++) {
+      fprintf(stderr, "m[r=%d c=%ld, i=%d]: %.03f", row, colind[i], i, csr_value[i]);
+    }
+    fprintf(stderr, "\n");
+  }*/
+
+  struct smat S1;
+  // A CSR matrix is the same as a Transposed CSC
+  S1.rows = cols;
+  S1.cols = rows;
+  S1.vals = vals;
+  S1.pointr = rowstart;
+  S1.rowind = colind;
+  S1.value  = csr_value;
+  fprintf(stderr, "Transposing\n");
+  SMat S2 = svdTransposeS(&S1);
+  fprintf(stderr, "transposed\n");
+  return S2;
 }
 
 long get_smat_rows(SMat m) { return m->rows; };

--- a/hmatrix-svdlibc.cabal
+++ b/hmatrix-svdlibc.cabal
@@ -1,5 +1,5 @@
 name:                hmatrix-svdlibc
-version:             0.3.2
+version:             0.4.0
 synopsis:            SVDLIBC bindings for HMatrix
 description:
   Bindings for the sparse singular value decomposition
@@ -12,7 +12,7 @@ maintainer:          bgamari.foss@gmail.com
 copyright:           (c) 2014 Ben Gamari
 category:            Math
 build-type:          Simple
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 extra-source-files:  cbits/*.c, include/*.h, svdlibc/*.c, svdlibc/*.h, svdlibc/README.md
 
 source-repository head
@@ -26,8 +26,8 @@ library
   Includes:            glue.h, svdlib.h
   build-depends:       base >=4.6 && <5.0,
                        hmatrix >=0.17 && <0.18,
-                       vector >= 0.11,
-                       vector-algorithms >= 0.7
+                       vector >= 0.11
+  default-language:    Haskell2010
 
 test-suite svdlibc-test
   type:                exitcode-stdio-1.0
@@ -40,8 +40,22 @@ test-suite svdlibc-test
                        base >=4.6 && <5.0,
                        hmatrix >=0.17 && <0.18,
                        vector >= 0.11,
-                       vector-algorithms >= 0.7,
                        hspec >= 2.2,
                        QuickCheck >= 2.8
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+benchmark svdlibc-benchmarks
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  c-sources:           cbits/glue.c, svdlibc/svdlib.c, svdlibc/svdutil.c, svdlibc/las2.c
+  include-dirs:        include, svdlibc
+  includes:            glue.h, svdlib.h
+  main-is:             Numeric/LinearAlgebra/SVD/Benchmarks.hs
+  build-depends:       hmatrix-svdlibc,
+                       base >=4.6 && <5.0,
+                       hmatrix >=0.17 && <0.18,
+                       vector >= 0.11,
+                       criterion >= 1.1
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/hmatrix-svdlibc.cabal
+++ b/hmatrix-svdlibc.cabal
@@ -25,12 +25,22 @@ library
   Include-dirs:        include, svdlibc
   Includes:            glue.h, svdlib.h
   build-depends:       base >=4.6 && <5.0,
-                       hmatrix >=0.16 && <0.18
+                       hmatrix >=0.17 && <0.18,
+                       vector >= 0.11,
+                       vector-algorithms >= 0.7
 
-executable svdlibc-test
-  main-is:             Test.hs
+test-suite svdlibc-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
   c-sources:           cbits/glue.c, svdlibc/svdlib.c, svdlibc/svdutil.c, svdlibc/las2.c
   include-dirs:        include, svdlibc
   includes:            glue.h, svdlib.h
-  build-depends:       base >=4.6 && <5.0,
-                       hmatrix >=0.16 && <0.18
+  main-is:             Numeric/LinearAlgebra/SVD/Spec.hs
+  build-depends:       hmatrix-svdlibc,
+                       base >=4.6 && <5.0,
+                       hmatrix >=0.17 && <0.18,
+                       vector >= 0.11,
+                       vector-algorithms >= 0.7,
+                       hspec >= 2.2
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010

--- a/hmatrix-svdlibc.cabal
+++ b/hmatrix-svdlibc.cabal
@@ -41,6 +41,7 @@ test-suite svdlibc-test
                        hmatrix >=0.17 && <0.18,
                        vector >= 0.11,
                        vector-algorithms >= 0.7,
-                       hspec >= 2.2
+                       hspec >= 2.2,
+                       QuickCheck >= 2.8
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/include/glue.h
+++ b/include/glue.h
@@ -11,4 +11,13 @@ double *get_dmat_buffer(DMat d);
 
 void free_dmat(DMat d);
 
+
+long get_smat_rows(SMat m);
+long get_smat_cols(SMat m);
+long *get_smat_pointr(SMat m);
+long *get_smat_rowind(SMat m);
+double *get_smat_value(SMat m);
+
+void free_smat(SMat m);
+
 void set_verbosity(long v);

--- a/include/glue.h
+++ b/include/glue.h
@@ -17,6 +17,7 @@ long get_smat_cols(SMat m);
 long *get_smat_pointr(SMat m);
 long *get_smat_rowind(SMat m);
 double *get_smat_value(SMat m);
+SMat svd_new_smat_from_csr(int rows, int cols, int vals, long *pointr, long *rowind, double *value);
 
 void free_smat(SMat m);
 

--- a/test/Numeric/LinearAlgebra/SVD/Benchmarks.hs
+++ b/test/Numeric/LinearAlgebra/SVD/Benchmarks.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Criterion.Main
+import qualified Data.Vector.Storable as Vec
+import Numeric.LinearAlgebra
+import Numeric.LinearAlgebra.Data
+import Numeric.LinearAlgebra.Devel
+import Numeric.LinearAlgebra.SVD.SVDLIBC as SVD
+import System.IO
+
+
+main :: IO ()
+main = defaultMain
+  [ bench "Factorizes a random dense matrix" $ nfIO $ do
+      let (width, height) = (20, 10)
+      SVD.svd (min width height) <$> randn width height
+  , bench "Factorizes a random sparse matrix" $ nfIO $ do
+      let (width, height) = (20, 10)
+      SVD.sparseSvd (min width height) <$> SVD.sparsify <$> randn width height
+  ]

--- a/test/Numeric/LinearAlgebra/SVD/Spec.hs
+++ b/test/Numeric/LinearAlgebra/SVD/Spec.hs
@@ -1,17 +1,35 @@
 {-# LANGUAGE OverloadedStrings #-}
 import Test.Hspec
-import qualified Data.Vector.Unboxed as Vec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck hiding ((><))
+import qualified Data.Vector.Storable as Vec
 import Numeric.LinearAlgebra
 import Numeric.LinearAlgebra.Data
+import Numeric.LinearAlgebra.Devel
 import Numeric.LinearAlgebra.SVD.SVDLIBC as SVD
-
+import Debug.Trace
 
 main :: IO ()
 main = hspec $ do
   describe "Dense matrices" $ do
-    it "Factorizes an identity matrix" $ do
-      mb <- randn 2 3
-      let m = fromBlocks [[mb, mb], [mb, mb]]
-      let (u,s,v) = SVD.svd 2 m
-      print $ (size u, size s, size v)
-      find (\x -> abs x > 0.01) ((tr u <> diag s <> v) - m) `shouldBe` []
+    prop "Factorizes a random matrix" $ \(width, items) ->
+      let height = length items `div` width
+          m = (width >< height) items
+          --m = fromBlocks [[mb, mb], [mb, mb]] -- tile it four times
+          short = min width height
+          (u,s',v) = SVD.svd short m
+          sp = vjoin [s', konst 0 (short - size s') ]
+          s = traceShow (tr u, sp, v, mconcat [tr u, diag sp, v] - m) sp
+      in  width <= 3
+          || height <= 3
+          || find (\x -> abs x > 0.001) (mconcat [tr u, diag s, v] - m) == []
+
+    --prop "Factorizes a random sparse matrix" $ \(width, items) ->
+      --let height = length items `div` width
+      --    mb = (width >< height) items
+      --    m = fromBlocks [[mb, mb], [mb, mb]]
+      --    csr = SVD.sparsify m
+      --    (u,s,v) = SVD.sparseSvd (min width height) csr
+      --in  width < 1
+      --    || height < 1
+      --    || find (\x -> abs x > 0.01) ((tr u <> diag s <> v) - m) == []

--- a/test/Numeric/LinearAlgebra/SVD/Spec.hs
+++ b/test/Numeric/LinearAlgebra/SVD/Spec.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Test.Hspec
+import qualified Data.Vector.Unboxed as Vec
+import Numeric.LinearAlgebra
+import Numeric.LinearAlgebra.Data
+import Numeric.LinearAlgebra.SVD.SVDLIBC as SVD
+
+
+main :: IO ()
+main = hspec $ do
+  describe "Dense matrices" $ do
+    it "Factorizes an identity matrix" $ do
+      mb <- randn 2 3
+      let m = fromBlocks [[mb, mb], [mb, mb]]
+      let (u,s,v) = SVD.svd 2 m
+      print $ (size u, size s, size v)
+      find (\x -> abs x > 0.01) ((tr u <> diag s <> v) - m) `shouldBe` []

--- a/test/Numeric/LinearAlgebra/SVD/Spec.hs
+++ b/test/Numeric/LinearAlgebra/SVD/Spec.hs
@@ -8,27 +8,53 @@ import Numeric.LinearAlgebra.Data
 import Numeric.LinearAlgebra.Devel
 import Numeric.LinearAlgebra.SVD.SVDLIBC as SVD
 import Debug.Trace
+import System.IO
+
+newtype RandHMat = RandHMat (Matrix Double) deriving Show
+
+instance Arbitrary (RandHMat) where
+  arbitrary = do
+    x <- arbitrary
+    y <- arbitrary
+    vector <- Vec.replicateM (x*y) arbitrary
+    return $ RandHMat $ reshape y vector
 
 main :: IO ()
 main = hspec $ do
-  describe "Dense matrices" $ do
-    prop "Factorizes a random matrix" $ \(width, items) ->
-      let height = length items `div` width
-          m = (width >< height) items
-          short = min width height
-          (u,s',v) = SVD.svd short m
-          s = vjoin [s', konst 0 (short - size s') ]
-      in  width <= 3
-          || height <= 3
-          || find (\x -> abs x > 0.001) (mconcat [tr u, diag s, v] - m) == []
+  let summat = Vec.foldr (+) 0 . flatten
+      validate u s v ref = summat (mconcat [tr u, diag s, v] - ref) / summat ref < 0.01
 
-    prop "Factorizes a random sparse matrix" $ \(width, items) ->
-      let height = length items `div` width
-          m = (width >< height) items
-          csr = SVD.sparsify m
+  describe "Dense matrices" $ do
+    it "Factorizes a random dense matrix" $ do
+      let (width, height) = (20, 10)
+      mat <- randn width height
+      short <- return $! min width height
+      (u,s',v) <- return $! SVD.svd short mat
+      s <- return $! vjoin [s', konst 0 (short - size s') ]
+      validate u s v mat `shouldBe` True
+
+
+    prop "Factorizes a random dense matrix (quickcheck)" $ \(RandHMat mat) ->
+      let (width, height) = size mat
           short = min width height
+          (u,s',v) = SVD.svd short mat
+          s = vjoin [s', konst 0 (short - size s') ]
+      in  (width > 1 && height > 1) ==> validate u s v mat
+
+  describe "Sparse matrices" $ do
+    it "Factorizes a random sparse matrix" $ do
+      let (width, height) = (20, 10)
+      m <- randn width height
+      csr <- return $! SVD.sparsify m
+      short <- return $! min width height
+      (u,s',v) <- return $! SVD.sparseSvd short csr
+      s <- return $! vjoin [s', konst 0 (short - size s') ]
+      validate u s v m `shouldBe` True
+
+    prop "Factorizes a random sparse matrix (quickcheck)" $ \(RandHMat mat) ->
+      let (width, height) = size mat
+          short = min width height
+          csr = SVD.sparsify mat
           (u,s',v) = SVD.sparseSvd short csr
           s = vjoin [s', konst 0 (short - size s') ]
-      in  width <= 3
-          || height <= 3
-          || find (\x -> abs x > 0.001) (mconcat [tr u, diag s, v] - m) == []
+      in  (width > 1 && height > 1) ==> validate u s v mat

--- a/test/Numeric/LinearAlgebra/SVD/Spec.hs
+++ b/test/Numeric/LinearAlgebra/SVD/Spec.hs
@@ -15,21 +15,20 @@ main = hspec $ do
     prop "Factorizes a random matrix" $ \(width, items) ->
       let height = length items `div` width
           m = (width >< height) items
-          --m = fromBlocks [[mb, mb], [mb, mb]] -- tile it four times
           short = min width height
           (u,s',v) = SVD.svd short m
-          sp = vjoin [s', konst 0 (short - size s') ]
-          s = traceShow (tr u, sp, v, mconcat [tr u, diag sp, v] - m) sp
+          s = vjoin [s', konst 0 (short - size s') ]
       in  width <= 3
           || height <= 3
           || find (\x -> abs x > 0.001) (mconcat [tr u, diag s, v] - m) == []
 
-    --prop "Factorizes a random sparse matrix" $ \(width, items) ->
-      --let height = length items `div` width
-      --    mb = (width >< height) items
-      --    m = fromBlocks [[mb, mb], [mb, mb]]
-      --    csr = SVD.sparsify m
-      --    (u,s,v) = SVD.sparseSvd (min width height) csr
-      --in  width < 1
-      --    || height < 1
-      --    || find (\x -> abs x > 0.01) ((tr u <> diag s <> v) - m) == []
+    prop "Factorizes a random sparse matrix" $ \(width, items) ->
+      let height = length items `div` width
+          m = (width >< height) items
+          csr = SVD.sparsify m
+          short = min width height
+          (u,s',v) = SVD.sparseSvd short csr
+          s = vjoin [s', konst 0 (short - size s') ]
+      in  width <= 3
+          || height <= 3
+          || find (\x -> abs x > 0.001) (mconcat [tr u, diag s, v] - m) == []


### PR DESCRIPTION
SVDLIBC uses sparse matrices, and HMatrix has sparse matrices, so we can solve sparse decompositions without converting through a dense matrix, hopefully saving some time but almost certainly saving memory.

There are some concerns about the patch though:
- `sparsify` isn't strictly necessary for using the library but it's nice for testing
- Provided `sparsify` is available, we may not need to introduce a new function `sparseSvd` and instead we can simply assert that you should sparsify first if you need to operate on dense matrices. (Although the performance may not be as good.) But that would break any existing code.
- It also includes some hspec+quickcheck tests and criterion benchmarks
