### PR TITLE
Widen hmatrix dependency

### DIFF
--- a/hmatrix-svdlibc.cabal
+++ b/hmatrix-svdlibc.cabal
@@ -26,7 +26,7 @@ library
   Include-dirs:        include, svdlibc
   Includes:            glue.h, svdlib.h
   build-depends:       base >=4.6 && <5.0,
-                       hmatrix >=0.17 && <0.18,
+                       hmatrix >=0.17 && <0.19,
                        vector >= 0.11
   default-language:    Haskell2010
 
@@ -39,7 +39,7 @@ test-suite svdlibc-test
   main-is:             Numeric/LinearAlgebra/SVD/Spec.hs
   build-depends:       hmatrix-svdlibc,
                        base >=4.6 && <5.0,
-                       hmatrix >=0.17 && <0.18,
+                       hmatrix >=0.17 && <0.19,
                        vector >= 0.11,
                        hspec >= 2.2,
                        QuickCheck >= 2.8
@@ -55,7 +55,7 @@ benchmark svdlibc-benchmarks
   main-is:             Numeric/LinearAlgebra/SVD/Benchmarks.hs
   build-depends:       hmatrix-svdlibc,
                        base >=4.6 && <5.0,
-                       hmatrix >=0.17 && <0.18,
+                       hmatrix >=0.17 && <0.19,
                        vector >= 0.11,
                        criterion >= 1.1
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
hmatrix 0.18.0.0 was released in November and doesn't appear to break anything for this library.